### PR TITLE
Adapt icon path removal from core

### DIFF
--- a/src/main/resources/net/hurstfrost/hudson/sounds/SoundsAgentAction/index.jelly
+++ b/src/main/resources/net/hurstfrost/hudson/sounds/SoundsAgentAction/index.jelly
@@ -7,7 +7,7 @@
 	<l:layout title="Sounds">
 		<l:side-panel>
 			<l:tasks>
-				<l:task icon="images/24x24/up.gif" href="${rootURL}/" title="${%Back to Dashboard}" />
+				<l:task icon="icon-up icon-md" href="${rootURL}/" title="${%Back to Dashboard}" />
 				<j:if test="${h.hasPermission(it, it.PERMISSION)}">
     				<l:task icon="plugin/sounds/icon/s_${it.globalMute?'off':'on'}_24x24.png" href="globalMute" post="true" title="${it.globalMute?'Enable':'Disable ALL'} sounds${it.globalMute?' (currently disabled)':''}" />
 				</j:if>


### PR DESCRIPTION
The change proposed prepares the plugin for the icon path removal from core in the upcoming LTS line. This change affects plugins not using the icon API or relying on paths. Plugins using the API properly in the first place are unaffected by this change.

Could you trigger a release after merging this PR please, giving people a chance to update the plugin before updating to the next LTS version @cafebabe 
Thanks in advance!